### PR TITLE
Mspm0

### DIFF
--- a/src/flash/nor/mspm0.c
+++ b/src/flash/nor/mspm0.c
@@ -621,6 +621,22 @@ static int mspm0_fctl_unprotect_sector(struct flash_bank *bank, uint32_t addr)
 	return ret;
 }
 
+static void mspm0_fctl_cfg_command(struct flash_bank *bank, uint32_t addr, uint32_t cmd, uint32_t byte_en)
+{
+	struct target *target = bank->target;
+
+	/*
+	 * Configure the flash operation within the CMDTYPE register, byte_en
+	 * bits if needed, and then set the address where the flash operation
+	 * will execute.
+	 */
+	target_write_u32(target, FCTL_REG_CMDTYPE, cmd);
+	if (byte_en != 0) {
+		target_write_u32(target, FCTL_REG_CMDBYTEN, byte_en);
+	}
+	target_write_u32(target, FCTL_REG_CMDADDR, addr);
+}
+
 static int msmp0_fctl_wait_cmd_ok(struct flash_bank *bank)
 {
 	struct target *target = bank->target;
@@ -888,9 +904,7 @@ static int mspm0_erase(struct flash_bank *bank, unsigned int first, unsigned int
 				  "(sector: %d)", mspm0_info->name, addr, csa);
 			return retval;
 		}
-		target_write_u32(target, FCTL_REG_CMDTYPE,
-				 (FCTL_CMDTYPE_COMMAND_ERASE | FCTL_CMDTYPE_SIZE_SECTOR));
-		target_write_u32(target, FCTL_REG_CMDADDR, addr);
+		mspm0_fctl_cfg_command(bank, addr, (FCTL_CMDTYPE_COMMAND_ERASE | FCTL_CMDTYPE_SIZE_SECTOR), 0);
 		target_write_u32(target, FCTL_REG_CMDEXEC, FCTL_CMDEXEC_VAL_EXECUTE);
 		retval = msmp0_fctl_wait_cmd_ok(bank);
 		if (retval) {
@@ -995,14 +1009,7 @@ static int mspm0_write(struct flash_bank *bank, const uint8_t *buffer,
 			return ERROR_FAIL;
 		}
 
-		target_write_u32(target, FCTL_REG_CMDTYPE,
-				 (FCTL_CMDTYPE_COMMAND_PROGRAM |
-				  FCTL_CMDTYPE_SIZE_ONEWORD));
-
-		/* When writing to part of flash_word - set the bit fields */
-		target_write_u32(target, FCTL_REG_CMDBYTEN, bytes_en);
-
-		target_write_u32(target, FCTL_REG_CMDADDR, offset);
+		mspm0_fctl_cfg_command(bank, offset, (FCTL_CMDTYPE_COMMAND_PROGRAM | FCTL_CMDTYPE_SIZE_ONEWORD), bytes_en);
 
 		retval = mspm0_fctl_unprotect_sector(bank, offset);
 		if (retval)

--- a/src/flash/nor/mspm0.c
+++ b/src/flash/nor/mspm0.c
@@ -106,7 +106,7 @@ struct mspm0_part_info {
 struct mspm0_family_info {
 	const char *family_name;
 	uint16_t part_num;
-	uint8_t part_count;
+	uint16_t part_count;
 	const struct mspm0_part_info *part_info;
 };
 
@@ -390,7 +390,7 @@ static int mspm0_read_part_info(struct flash_bank *bank)
 	}
 
 	/* Check if we at least know the family of devices */
-	for (int i = 0; i < (int)ARRAY_SIZE(mspm0_finf); i++) {
+	for (unsigned int i = 0; i < ARRAY_SIZE(mspm0_finf); i++) {
 		if (mspm0_finf[i].part_num == pnum) {
 			minfo_idx = i;
 			minfo = &mspm0_finf[i];
@@ -467,7 +467,7 @@ const struct {
 
 static void msmp0_fctl_translate_ret_err(uint32_t return_code, char *ret_str)
 {
-	for (unsigned long i = 0; i < ARRAY_SIZE(mspm0_fctl_fail_decode_strings); i++) {
+	for (unsigned int i = 0; i < ARRAY_SIZE(mspm0_fctl_fail_decode_strings); i++) {
 		if (return_code & BIT(mspm0_fctl_fail_decode_strings[i].bit_offset)) {
 			strncat(ret_str, mspm0_fctl_fail_decode_strings[i].fail_string,
 				ERR_STRING_MAX);
@@ -481,11 +481,11 @@ static int mspm0_fctl_get_sector_reg(struct flash_bank *bank, uint32_t addr,
 {
 	struct mspm0_flash_bank *mspm0_info = bank->driver_priv;
 	struct target *target = bank->target;
-	uint32_t sector_num = (addr >> 10);
-	uint32_t sector_in_bank = sector_num;
-	uint32_t phys_sector_num = sector_num;
+	uint16_t sector_num = (addr >> 10);
+	uint16_t sector_in_bank = sector_num;
+	uint16_t phys_sector_num = sector_num;
 	uint32_t sysctl_sec_status;
-	uint32_t exec_upper_bank;
+	bool exec_upper_bank;
 
 	/*
 	 * If the device has dual banks we will need to check if it is configured
@@ -574,8 +574,8 @@ static int msmp0_fctl_wait_cmd_ok(struct flash_bank *bank)
 	struct target *target = bank->target;
 	struct mspm0_flash_bank *mspm0_info = bank->driver_priv;
 	uint32_t return_code = 0;
-	long long start_ms;
-	long long elapsed_ms;
+	int64_t start_ms;
+	int64_t elapsed_ms;
 
 	int retval = ERROR_OK;
 

--- a/src/flash/nor/mspm0.c
+++ b/src/flash/nor/mspm0.c
@@ -519,19 +519,19 @@ static int mspm0_fctl_get_sector_reg(struct flash_bank *bank, uint32_t addr,
 
 	if (sector_num < mspm0_info->main_flash_size_kb) {
 		/* Use CMDWEPROTA */
-		if (phys_sector_num < (uint32_t)32) {
-			*sector_mask = (uint32_t)1 << phys_sector_num;
+		if (phys_sector_num < 32) {
+			*sector_mask = BIT(phys_sector_num);
 			*reg = FCTL_REG_CMDWEPROTA;
 			return ERROR_OK;
 		}
 
 		/* Use CMDWEPROTB */
-		if (sector_in_bank < (uint32_t)256) {
+		if (sector_in_bank < 256) {
 			/* Dual bank system */
 			if (mspm0_info->main_flash_num_banks > 1) {
-				*sector_mask = (uint32_t)1 << (sector_in_bank / 8);
+				*sector_mask = BIT(sector_in_bank / 8);
 			} else {	/* Single bank system */
-				*sector_mask = (uint32_t)1 << ((sector_in_bank - 32) / 8);
+				*sector_mask = BIT((sector_in_bank - 32) / 8);
 			}
 			*reg = FCTL_REG_CMDWEPROTB;
 			return ERROR_OK;
@@ -544,7 +544,7 @@ static int mspm0_fctl_get_sector_reg(struct flash_bank *bank, uint32_t addr,
 		 * will return an error.
 		 */
 		if (addr >= MSPM0_FLASH_BASE_NONMAIN && addr <= MSPM0_FLASH_END_NONMAIN) {
-			*sector_mask = 1 << (sector_num % 32);
+			*sector_mask = BIT(sector_num % 32);
 			*reg = FCTL_REG_CMDWEPROTNM;
 			return ERROR_OK;
 		}

--- a/src/flash/nor/mspm0.c
+++ b/src/flash/nor/mspm0.c
@@ -32,6 +32,7 @@
 
 /* MPM0 FCTL registers */
 #define FLASH_CONTROL_BASE				(0x400cd000)
+#define FCTL_REG_DESC					(FLASH_CONTROL_BASE + 0x10FC)
 #define FCTL_REG_CMDEXEC				(FLASH_CONTROL_BASE + 0x1100)
 #define FCTL_REG_CMDTYPE				(FLASH_CONTROL_BASE + 0x1104)
 #define FCTL_REG_CMDADDR				(FLASH_CONTROL_BASE + 0x1120)
@@ -62,10 +63,21 @@
 #define FCTL_CMDTYPE_SIZE_ONEWORD		(0x00000000U)
 #define FCTL_CMDTYPE_SIZE_SECTOR		(0x00000040U)
 
+/* FCTL_REG_DESC[FEATUREVER] Bits*/
+#define FCTL_FEATURE_VER_B_MIN			(0xAU)
+
 #define MSPM0_MAX_PROTREGS				(3)
 
 #define MSPM0_FLASH_TIMEOUT_MS			(8000)
 #define ERR_STRING_MAX					(255)
+
+/* TI manufacturer ID*/
+#define TI_MANUFACTURER_ID				(0x17U)
+
+/* Probe status states*/
+#define MSPM0_NO_ID_FOUND				(0)
+#define MSPM0_DEV_ID_FOUND				(1)
+#define MSPM0_DEV_PART_ID_FOUND			(2)
 
 /* SYSCTL BASE*/
 #define SYSCTL_BASE						(0x400AF000U)
@@ -95,6 +107,9 @@ struct mspm0_flash_bank {
 	/* Protection register stuff */
 	uint32_t protect_reg_base;
 	uint32_t protect_reg_count;
+
+	/* Flashctl version: A - CMDWEPROTA/B, B - CMDWEPROTB*/
+	uint8_t flash_version;
 };
 
 struct mspm0_part_info {
@@ -361,26 +376,36 @@ static int mspm0_read_part_info(struct flash_bank *bank)
 {
 	struct mspm0_flash_bank *mspm0_info = bank->driver_priv;
 	struct target *target = bank->target;
-	uint32_t did, userid, flashram;
+	uint32_t did, userid, flashram, flashdesc;
 	uint8_t minfo_idx = 0xff;
 	uint8_t pinfo_idx = 0xff;
-	uint16_t pnum, part;
+	uint8_t probe_status = MSPM0_NO_ID_FOUND;
+	uint16_t pnum, part, manufacturer;
 	uint8_t variant, version;
 	const struct mspm0_family_info *minfo = NULL;
 
-	/* Read and parse chip identification register */
+	/* Read and parse chip identification register and flash desc register */
 	target_read_u32(target, MSPM0_DID, &did);
 	target_read_u32(target, MSPM0_TRACEID, &mspm0_info->traceid);
 	target_read_u32(target, MSPM0_USERID, &userid);
 	target_read_u32(target, MSPM0_SRAMFLASH, &flashram);
+	target_read_u32(target, FCTL_REG_DESC, &flashdesc);
 
 	version = mspm0_extract_val(did, 31, 28);
 	pnum = mspm0_extract_val(did, 27, 12);
+	manufacturer = mspm0_extract_val(did, 11, 1);
 	variant = mspm0_extract_val(userid, 23, 16);
 	part = mspm0_extract_val(userid, 15, 0);
 
-	/* Valid DIEID? - check the ALWAYS_1 bit to be 1 */
-	if (!(did & BIT(0))) {
+	/*
+	 * Valid DIE and manufacturer ID?
+	 * Check the ALWAYS_1 bit to be 1 and manufacturer to be 0x17. All MSPM0
+	 * devices within the Device ID field of the factory constants will
+	 * always read 0x17 as it is TI's JEDEC bank and company code. If 0x17
+	 * and 1 from the ALWAYS_1 bit then it truly is not a MSPM0 device
+	 * so we will return an error instead of going any further.
+	 */
+	if (!(did & BIT(0)) || manufacturer != TI_MANUFACTURER_ID) {
 		LOG_WARNING("Unknown Device ID[0x%" PRIx32 "], cannot identify target",
 			    did);
 		LOG_DEBUG("did 0x%" PRIx32 ", traceid 0x%" PRIx32 ", userid 0x%" PRIx32
@@ -394,38 +419,64 @@ static int mspm0_read_part_info(struct flash_bank *bank)
 		if (mspm0_finf[i].part_num == pnum) {
 			minfo_idx = i;
 			minfo = &mspm0_finf[i];
+			probe_status = MSPM0_DEV_ID_FOUND;
 			break;
 		}
 	}
 
-	if (minfo_idx == 0xff) {
-		LOG_WARNING("Unsupported DeviceID[0x%" PRIx32 "], cannot identify target",
-			    pnum);
-		LOG_DEBUG("did 0x%" PRIx32 ", traceid 0x%" PRIx32 ", userid 0x%" PRIx32
-			  ", flashram 0x%" PRIx32 "", did, mspm0_info->traceid, userid,
-			  flashram);
-		LOG_DEBUG("Part 0x%" PRIx32 ", Part Num 0x%" PRIx32 ", Variant 0x%" PRIx32
-			  ", version 0x%" PRIx32, part, pnum, variant, version);
-		return ERROR_FLASH_OPERATION_FAILED;
-	}
-
-	/* Can we specifically identify the chip */
-	for (int i = 0; i < minfo->part_count; i++) {
-		if (minfo->part_info[i].part == part
-		    && minfo->part_info[i].variant == variant) {
-			pinfo_idx = i;
-			break;
+	/*
+	 * If we can identify the part number then we will attempt to identify
+	 * the specific chip. Otherwise if we do not know the part number then
+	 * it would be useless to identify the specific chip.
+	 */
+	if (minfo_idx != 0xff) {
+		/* Can we specifically identify the chip */
+		for (int i = 0; i < minfo->part_count; i++) {
+			if (minfo->part_info[i].part == part
+				&& minfo->part_info[i].variant == variant) {
+				pinfo_idx = i;
+				probe_status = MSPM0_DEV_PART_ID_FOUND;
+				break;
+			}
 		}
 	}
-	if (minfo_idx == 0xff) {
+
+	/*
+	 * We will check the status of our probe within this switch-case statement
+	 * with these three scenarios.
+	 *
+	 * 1) Device, part, and variant ID is unknown.
+	 * 2) Device ID is known but the part/variant ID is unknown.
+	 * 3) Device ID and part/variant ID is known.
+	 *
+	 * For scenario 1, we allow the user to continue because if the
+	 * manufacturer matches TI's JEDEC value and ALWAYS_1 from the device ID
+	 * field is correct then the assumption the user is using an MSPM0 device
+	 * can be made.
+	 *
+	 * Future development will be made to update the table as the portfolio
+	 * expands.
+	 */
+	switch (probe_status) {
+	case MSPM0_NO_ID_FOUND:
+		mspm0_info->name = "mspm0x";
+		LOG_INFO("Unidentified PART[0x%" PRIx32 "]/variant[0x%" PRIx32
+				"], unknown DeviceID[0x%" PRIx32
+				"]. Attempting to proceed as %s.", part, variant, pnum,
+		mspm0_info->name);
+		break;
+	case MSPM0_DEV_ID_FOUND:
 		mspm0_info->name = mspm0_finf[minfo_idx].family_name;
 		LOG_WARNING("Unidentified PART[0x%" PRIx32 "]/variant[0x%" PRIx32
-			    "], known DeviceID[0x%" PRIx32
-			    "]. Attempting to proceed as %s.", part, variant, pnum,
+				"], known DeviceID[0x%" PRIx32
+				"]. Attempting to proceed as %s.", part, variant, pnum,
 			    mspm0_info->name);
-	} else {
+		break;
+	case MSPM0_DEV_PART_ID_FOUND:
+	default:
 		mspm0_info->name = mspm0_finf[minfo_idx].part_info[pinfo_idx].part_name;
 		LOG_DEBUG("Part: %s detected", mspm0_info->name);
+		break;
 	}
 
 	mspm0_info->did = did;
@@ -434,6 +485,7 @@ static int mspm0_read_part_info(struct flash_bank *bank)
 	mspm0_info->main_flash_size_kb = mspm0_extract_val(flashram, 11, 0);
 	mspm0_info->main_flash_num_banks = mspm0_extract_val(flashram, 13, 12) + 1;
 	mspm0_info->sram_size_kb = mspm0_extract_val(flashram, 25, 16);
+	mspm0_info->flash_version = mspm0_extract_val(flashdesc, 15, 12);
 
 	/*
 	 * Hardcode flash_word_size unless we find some other pattern
@@ -1034,8 +1086,18 @@ static int mspm0_probe(struct flash_bank *bank)
 	case MSPM0_FLASH_BASE_MAIN:
 		bank->size = (mspm0_info->main_flash_size_kb * 1024);
 		bank->num_sectors = bank->size / mspm0_info->sector_size;
-		mspm0_info->protect_reg_base = FCTL_REG_CMDWEPROTA;
-		mspm0_info->protect_reg_count = 3;
+		/*
+		 * If the feature version bit read from the FCTL_REG_DESC is
+		 * greater than or equal to 0xA then it means that the device
+		 * will exclusively use CMDWEPROTB ONLY for MAIN memory protection
+		 */
+		if (mspm0_info->flash_version >= FCTL_FEATURE_VER_B_MIN) {
+			mspm0_info->protect_reg_base = FCTL_REG_CMDWEPROTB;
+			mspm0_info->protect_reg_count = 1;
+		} else {
+			mspm0_info->protect_reg_base = FCTL_REG_CMDWEPROTA;
+			mspm0_info->protect_reg_count = 3;
+		}
 		break;
 	case MSPM0_FLASH_BASE_DATA:
 		if (!mspm0_info->data_flash_size_kb) {
@@ -1044,9 +1106,16 @@ static int mspm0_probe(struct flash_bank *bank)
 			bank->num_sectors = 0x0;
 			return ERROR_OK;
 		}
+		/*
+		 * Any MSPM0 device containing data bank will have a flashctl
+		 * feature version of 0xA or higher. Since data bank is treated
+		 * like MAIN memory, it will also exclusively use CMDWEPROTB for
+		 * protection.
+		 */
 		bank->size = (mspm0_info->main_flash_size_kb * 1024);
 		bank->num_sectors = bank->size / mspm0_info->sector_size;
-		bank->num_prot_blocks = 0;	/* There is no protection here */
+		mspm0_info->protect_reg_base = FCTL_REG_CMDWEPROTB;
+		mspm0_info->protect_reg_count = 1;
 		break;
 	default:
 		LOG_ERROR("%s: Invalid bank address " TARGET_ADDR_FMT, mspm0_info->name,


### PR DESCRIPTION
flash/nor: Updating datatypes, probe, and command configurations

Updating variables to properly utilize data types they are entitled to.
Updating mspm0 probe sequence to provide an understanding of different flash types and manufacturer ID
Creating configuration function to allow cleaner flash operation