### PR TITLE
src/flash/nor/mspm0.c: Update protection status output and removing e…

### DIFF
--- a/src/flash/nor/mspm0.c
+++ b/src/flash/nor/mspm0.c
@@ -815,6 +815,17 @@ static int mspm0_protect_check(struct flash_bank *bank)
 {
 	struct mspm0_flash_bank *mspm0_info = bank->driver_priv;
 
+	/*
+	 * TRM Says:
+	 * Note that the CMDWEPROTx registers are reset to a protected state
+	 * at the end of all program and erase operations.  These registers
+	 * must be re-configured by software before a new operation is
+	 * initiated.
+	 *
+	 * To deal with this protection scheme, the CMDWEPROTx register that
+	 * correlates to the sector is modified at the time of operation.
+	 */
+
 	if (mspm0_info->did == 0)
 		return ERROR_FLASH_BANK_NOT_PROBED;
 


### PR DESCRIPTION
…xcess functions

According to reviews, the implementation of outputting the protection status was not ideal. To address reviewers concern the status of protection will always display unprotected. Within this commit other protection functions are removed as well since they will be never utilized due to how protection is displayed.

Change-Id: I4111506a7ef5c45e483e34b4a6adaa855596daee