### PR TITLE
src/flash/nor/mspm0.c: Fix byte size issue and resolve write alignmen…

### DIFF
--- a/src/flash/nor/mspm0.c
+++ b/src/flash/nor/mspm0.c
@@ -1020,7 +1020,7 @@ static int mspm0_write(struct flash_bank *bank, const unsigned char *buffer,
 		if (retval)
 			return retval;
 
-		retval = target_write_memory(target, FCTL_REG_CMDDATA0, 4, num_bytes_to_write / 4, buffer);
+		retval = target_write_buffer(target, FCTL_REG_CMDDATA0, num_bytes_to_write, buffer);
 		if (retval)
 			return retval;
 

--- a/src/flash/nor/mspm0.c
+++ b/src/flash/nor/mspm0.c
@@ -958,12 +958,6 @@ static int mspm0_write(struct flash_bank *bank, const unsigned char *buffer,
 	if (mspm0_info->did == 0)
 		return ERROR_FLASH_BANK_NOT_PROBED;
 
-	if (offset % mspm0_info->flash_word_size_bytes) {
-		LOG_ERROR("%s: Offset 0x%0" PRIx32 " Must be aligned to %d bytes",
-			mspm0_info->name, bank->write_start_alignment, bank->write_end_alignment);
-		return ERROR_FLASH_DST_BREAKS_ALIGNMENT;
-	}
-
 	/*
 	 * Pick a copy of the current protection config for later restoration
 	 * We need to restore these regs after every write, so instead of trying
@@ -1026,7 +1020,7 @@ static int mspm0_write(struct flash_bank *bank, const unsigned char *buffer,
 		if (retval)
 			return retval;
 
-		retval = target_write_memory(target, FCTL_REG_CMDDATA0, 1, num_bytes_to_write, buffer);
+		retval = target_write_memory(target, FCTL_REG_CMDDATA0, 4, num_bytes_to_write / 4, buffer);
 		if (retval)
 			return retval;
 
@@ -1091,6 +1085,9 @@ static int mspm0_probe(struct flash_bank *bank)
 		free(bank->sectors);
 		bank->sectors = NULL;
 	}
+
+	bank->write_start_alignment = 4;
+	bank->write_end_alignment = 4;
 
 	switch (bank->base) {
 	case MSPM0_FLASH_BASE_NONMAIN:


### PR DESCRIPTION
…t concern

Resolved byte size issue with target_write_memory() API. Also updated probe to enforce the alignment values for start and end of writes. With the write alignment variable it is set to 4 because due to the fact we utilize only CMDDATA0 which is 32-bits (8-bytes).

Change-Id: Ib4fd963d22d8c9a2f0358dc96081cac3a2285c71